### PR TITLE
fix textlint action error

### DIFF
--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -13,8 +13,11 @@ jobs:
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v2.1.1
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         with:
           node-version: '12.x'
+        
       
       - name: Install dependencies
         run: cd .operations/ && npm install


### PR DESCRIPTION
ちょうど2020年11月16日で利用不可になるコマンドを使っていたっぽい。textlint がエラーになるので、とりあえず応急処置します。

![image](https://user-images.githubusercontent.com/23182489/99386064-3bd81100-2915-11eb-9afa-32ce151b572f.png)
